### PR TITLE
Temporary fix for `setjmp()` crashes on scripts executed by `dofile()`

### DIFF
--- a/lbaselib.c
+++ b/lbaselib.c
@@ -395,14 +395,14 @@ static int dofilecont (lua_State *L, int d1, lua_KContext d2) {
   return lua_gettop(L) - 1;
 }
 
-
+static int finishpcall (lua_State *L, int status, lua_KContext extra); // provide prototype early
 static int luaB_dofile (lua_State *L) {
   const char *fname = luaL_optstring(L, 1, NULL);
   lua_settop(L, 1);
   if (l_unlikely(luaL_loadfile(L, fname) != LUA_OK))
     return lua_error(L);
-  lua_callk(L, 0, LUA_MULTRET, 0, dofilecont);
-  return dofilecont(L, 0, 0);
+  int status = lua_pcallk(L, 0, LUA_MULTRET, 0, 0, dofilecont);
+  return finishpcall(L, status, 0); //El_isra: longjmp() is crashing. doing a protected call makes `dofile()` return instead of crashing
 }
 
 

--- a/lbaselib.c
+++ b/lbaselib.c
@@ -396,7 +396,7 @@ static int dofilecont (lua_State *L, int d1, lua_KContext d2) {
 }
 
 static int finishpcall (lua_State *L, int status, lua_KContext extra); // provide prototype early
-static int luaB_dofile (lua_State *L) {
+static int luaB_dofile_protected (lua_State *L) {
   const char *fname = luaL_optstring(L, 1, NULL);
   lua_settop(L, 1);
   if (l_unlikely(luaL_loadfile(L, fname) != LUA_OK))
@@ -405,6 +405,14 @@ static int luaB_dofile (lua_State *L) {
   return finishpcall(L, status, 0); //El_isra: longjmp() is crashing. doing a protected call makes `dofile()` return instead of crashing
 }
 
+static int luaB_dofile (lua_State *L) {
+  const char *fname = luaL_optstring(L, 1, NULL);
+  lua_settop(L, 1);
+  if (l_unlikely(luaL_loadfile(L, fname) != LUA_OK))
+    return lua_error(L);
+  lua_callk(L, 0, LUA_MULTRET, 0, dofilecont);
+  return dofilecont(L, 0, 0);
+}
 
 static int luaB_assert (lua_State *L) {
   if (l_likely(lua_toboolean(L, 1)))  /* condition is true? */
@@ -491,6 +499,7 @@ static const luaL_Reg base_funcs[] = {
   {"assert", luaB_assert},
   {"collectgarbage", luaB_collectgarbage},
   {"dofile", luaB_dofile},
+  {"dofile_protected", luaB_dofile_protected},
   {"error", luaB_error},
   {"getmetatable", luaB_getmetatable},
   {"ipairs", luaB_ipairs},

--- a/sample/Makefile
+++ b/sample/Makefile
@@ -6,7 +6,7 @@ EE_BIN = mini_luap.elf
 
 EE_OBJS = mini_luap.o
 
-EE_LIBS   += -L$(PS2SDK)/ports/lib -L../lib -ldebug -llua
+EE_LIBS   += -L$(PS2SDK)/ports/lib -L../lib -ldebug ../liblua.a
 EE_INCS   += -I../include -Iinclude -I$(PS2SDK)/ports/include -I../src
 
 all: $(EE_BIN)

--- a/sample/Makefile
+++ b/sample/Makefile
@@ -6,8 +6,8 @@ EE_BIN = mini_luap.elf
 
 EE_OBJS = mini_luap.o
 
-EE_LIBS   += -L$(PS2SDK)/ports/lib -L../lib -ldebug -llua
-EE_INCS   += -I../include -Iinclude -I$(PS2SDK)/ports/include -I../src
+EE_LIBS   += -L$(PS2SDK)/ports/lib -L../lib -ldebug ../liblua.a
+EE_INCS   += -I../include -Iinclude  -I../src -I..
 
 all: $(EE_BIN)
 


### PR DESCRIPTION
When a Lua error arises on any script loaded by Lua `dofile()` (or when any action involving setjmp happens, such as Lua `error()` or `assert()`) the program crashes. PS2LINK gives EPC `0x45`.

This is a temporary solution so that we can still debug on chain loaded scripts.

With this PR, a new variant, called `dofile_protected()` will be available. This new function runs on protected mode, returning a boolean indicating if execution was successful, and if it wasn't, the error string is also returned.